### PR TITLE
fix buildscript incorrectly timed out on getting mapping

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -97,7 +97,11 @@ sourceSets {
 
 repositories {
     mavenCentral()
-    maven("https://maven.yqloss.net")
+    maven("https://maven.yqloss.net") {
+        content {
+            includeGroup("net.yqloss")
+        }
+    }
     maven("https://repo.polyfrost.org/releases")
     maven("https://repo.hypixel.net/repository/Hypixel/")
 }


### PR DESCRIPTION
Instead it will timed out on getting `net.yqloss:uktil` dependency if can't connect to the maven server